### PR TITLE
fix: drop raw search text from tag suggestions

### DIFF
--- a/src/search-editor/SuggesterComponent.tsx
+++ b/src/search-editor/SuggesterComponent.tsx
@@ -13,6 +13,7 @@ import { useRenderSelectOptions } from './hooks/useRenderSelectOption';
 import { useSuggestInput } from './hooks/useSuggestInput';
 import { MentionSuggester, MentionSuggesterProps } from './MentionSuggester';
 import { Fields, GetSuggestions, INPUT_OPTION } from './types';
+import { prepareSuggestedItems } from './utils/prepare-suggested-items';
 
 const GET_SUGGESTIONS_DEBOUNCE_MS = 300;
 
@@ -91,11 +92,12 @@ export function SuggesterComponent({
 				input: searchInput,
 			});
 
-			const newSuggestedItems = [
-				...(inputOption || []),
-				...(options || []),
-				...selectOptions,
-			];
+			const newSuggestedItems = prepareSuggestedItems({
+				options,
+				inputOption,
+				selectOptions,
+				searchInput,
+			});
 
 			setSuggestedItems(newSuggestedItems);
 			setIsLoading(false);

--- a/src/search-editor/utils/__tests__/prepare-suggested-items.spec.ts
+++ b/src/search-editor/utils/__tests__/prepare-suggested-items.spec.ts
@@ -1,0 +1,36 @@
+import type { NamedMentionExtensionAttributes } from 'remirror/extensions';
+
+import { INPUT_OPTION } from '../../types';
+import { prepareSuggestedItems } from '../prepare-suggested-items';
+
+describe('prepareSuggestedItems', () => {
+	const selectOptions: NamedMentionExtensionAttributes[] = [];
+
+	it('omits input option when suggestions exist and adds matchedText', () => {
+		const options: NamedMentionExtensionAttributes[] = [
+			{ id: '1', label: 'label', name: 'tag' },
+		];
+
+		const result = prepareSuggestedItems({
+			options,
+			inputOption: [INPUT_OPTION],
+			selectOptions,
+			searchInput: 'comm',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ id: '1', matchedText: 'comm' });
+	});
+
+	it('includes input option when no suggestions exist', () => {
+		const result = prepareSuggestedItems({
+			options: [],
+			inputOption: [INPUT_OPTION],
+			selectOptions,
+			searchInput: 'comm',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual(INPUT_OPTION);
+	});
+});

--- a/src/search-editor/utils/prepare-suggested-items.ts
+++ b/src/search-editor/utils/prepare-suggested-items.ts
@@ -1,0 +1,26 @@
+import { NamedMentionExtensionAttributes } from 'remirror/extensions';
+
+/**
+ * Prepares the list of suggested items to display.
+ *
+ * - Adds the current search input as the `matchedText` for each suggestion so
+ *   that the typed query can be removed from the editor when the suggestion is
+ *   inserted.
+ * - Only includes the `INPUT_OPTION` when no other suggestions are available.
+ */
+export function prepareSuggestedItems(params: {
+	options?: NamedMentionExtensionAttributes[];
+	inputOption?: NamedMentionExtensionAttributes[];
+	selectOptions: NamedMentionExtensionAttributes[];
+	searchInput?: string;
+}): NamedMentionExtensionAttributes[] {
+	const { options, inputOption, selectOptions, searchInput } = params;
+	const mappedOptions = (options ?? []).map(option => ({
+		...option,
+		matchedText: searchInput,
+	}));
+
+	const includeInput = mappedOptions.length > 0 ? [] : inputOption ?? [];
+
+	return [...includeInput, ...mappedOptions, ...selectOptions];
+}


### PR DESCRIPTION
Typing part of a tag showed the raw input as the top suggestion, and selecting it produced malformed tag tokens. The suggestion preparation logic now filters out the raw search term when other matches exist and injects the typed text as `matchedText` so the selected tag fully replaces the input.

Fixes https://github.com/Collaborne/backlog/issues/4169