### PR TITLE
Fix invalid content error for empty mention labels in search editor initialization

### DIFF
--- a/src/search-editor/utils/__tests__/search-to-remirror.spec.ts
+++ b/src/search-editor/utils/__tests__/search-to-remirror.spec.ts
@@ -174,4 +174,57 @@ describe('search-to-remirror', () => {
 			],
 		});
 	});
+
+	it('falls back to id when mention label is empty', async () => {
+		const fieldsWithEmptyLabel: Fields = {
+			...FIELDS,
+			label: {
+				...FIELDS.label,
+				getExtraAttrs: async (id: string) => {
+					if (!id) {
+						return;
+					}
+					return { id, label: '', name: 'label' };
+				},
+			},
+		};
+
+		const actual = await searchToRemirror({
+			searchQuery: 'label:___label#label1',
+			fields: fieldsWithEmptyLabel,
+		});
+
+		expect(actual).toEqual({
+			type: 'doc',
+			content: [
+				{
+					type: 'paragraph',
+					content: [
+						{
+							text: 'label:',
+							type: 'text',
+						},
+						{
+							marks: [
+								{
+									attrs: {
+										id: '___label#label1',
+										label: '',
+										name: 'label',
+									},
+									type: 'mention',
+								},
+							],
+							text: '___label#label1',
+							type: 'text',
+						},
+						{
+							text: ' ',
+							type: 'text',
+						},
+					],
+				},
+			],
+		});
+	});
 });

--- a/src/search-editor/utils/search-to-remirror.ts
+++ b/src/search-editor/utils/search-to-remirror.ts
@@ -51,6 +51,10 @@ function createMentionMarkJSON(
 	if (!attrs) {
 		return [];
 	}
+
+	// ProseMirror rejects empty text nodes. Fall back to id when label is empty.
+	const mentionText = `${attrs.label ?? ''}` || `${attrs.id ?? ''}`;
+
 	return [
 		{
 			type: 'text',
@@ -58,7 +62,7 @@ function createMentionMarkJSON(
 		},
 		{
 			type: 'text',
-			text: String(attrs.label),
+			text: mentionText,
 			marks: [
 				{
 					type: 'mention',


### PR DESCRIPTION
This change fixes a crash during editor initialization.

The problem was that when a mention had an empty label, we created a mention text node with an empty string. ProseMirror does not allow empty text nodes, so Remirror failed when setting content.

The fix is simple: when building mention text, we now use the label if it exists, and fall back to the mention id if the label is empty. This keeps the generated document valid.